### PR TITLE
Allow all origins

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -33,12 +33,7 @@ func ConfigGetter(e config.ExtraConfig) interface{} {
 	}
 
 	cfg := Config{}
-	allowOrigins := getList(tmp, "allow_origins")
-	if len(allowOrigins) > 0 {
-		cfg.AllowOrigins = allowOrigins
-	} else {
-		return nil
-	}
+	cfg.AllowOrigins = getList(tmp, "allow_origins")
 
 	cfg.AllowMethods = getList(tmp, "allow_methods")
 	cfg.AllowHeaders = getList(tmp, "allow_headers")

--- a/cors_test.go
+++ b/cors_test.go
@@ -73,7 +73,7 @@ func TestDefaultConfiguration(t *testing.T) {
 	}
 }
 
-func TestWrongOrEmptyConfiguration(t *testing.T) {
+func TestWrongConfiguration(t *testing.T) {
 	sampleCfg := map[string]interface{}{}
 	if _, ok := ConfigGetter(sampleCfg).(Config); ok {
 		t.Error("The config should be nil\n")
@@ -82,15 +82,15 @@ func TestWrongOrEmptyConfiguration(t *testing.T) {
 	if _, ok := ConfigGetter(badCfg).(Config); ok {
 		t.Error("The config should be nil\n")
 	}
+}
 
+func TestEmptyConfiguration(t *testing.T) {
 	noOriginCfg := map[string]interface{}{}
 	serialized := []byte(`{ "github_com/devopsfaith/krakend-cors": {
-			"allow_origins": "",
-			"allow_headers": [ "Content-Type" ]
 			}
 		}`)
 	json.Unmarshal(serialized, &noOriginCfg)
-	if v, ok := ConfigGetter(noOriginCfg).(Config); ok {
-		t.Errorf("The configuration should be nil, the Origin must not be empty: %v\n", v)
+	if v, ok := ConfigGetter(noOriginCfg).(Config); !ok {
+		t.Errorf("The configuration should not be empty: %v\n", v)
 	}
 }

--- a/gin/cors.go
+++ b/gin/cors.go
@@ -17,7 +17,22 @@ func New(e config.ExtraConfig) gin.HandlerFunc {
 	if !ok {
 		return nil
 	}
+
+	var allowAllOrigins bool
+	if len(cfg.AllowOrigins) == 0 {
+		allowAllOrigins = true
+	} else {
+		for _, origin := range cfg.AllowOrigins {
+			if origin == "*" {
+				allowAllOrigins = true
+				cfg.AllowOrigins = nil
+				break
+			}
+		}
+	}
+
 	return cors.New(cors.Config{
+		AllowAllOrigins:  allowAllOrigins,
 		AllowOrigins:     cfg.AllowOrigins,
 		AllowMethods:     cfg.AllowMethods,
 		AllowHeaders:     cfg.AllowHeaders,

--- a/mux/cors_test.go
+++ b/mux/cors_test.go
@@ -43,6 +43,32 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestAllowOriginEmpty(t *testing.T) {
+	sampleCfg := map[string]interface{}{}
+	serialized := []byte(`{ "github_com/devopsfaith/krakend-cors": {
+			}
+		}`)
+	json.Unmarshal(serialized, &sampleCfg)
+	h := New(sampleCfg)
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "origin")
+	req.Header.Add("Origin", "http://foobar.com")
+	handler := h.Handler(testHandler)
+	handler.ServeHTTP(res, req)
+	if res.Code != 200 {
+		t.Errorf("Invalid status code: %d should be 200", res.Code)
+	}
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET",
+		"Access-Control-Allow-Headers": "Origin",
+	})
+}
+
 var allHeaders = []string{
 	"Vary",
 	"Access-Control-Allow-Origin",


### PR DESCRIPTION
Fixes https://github.com/gin-contrib/cors/issues/37 that ignores an empty `AllowOrigin` as a wildcard (as stated in the documentation).

Added tests to check for this behaviour in the mux and gin adapters.